### PR TITLE
Fix SBT dependencies

### DIFF
--- a/joda-beans/dependency-info.html
+++ b/joda-beans/dependency-info.html
@@ -181,7 +181,7 @@
 <div class="section">
 <h3>SBT<a name="SBT"></a></h3><a name="SBT"></a>
 <div class="source">
-<pre>libraryDependencies += &quot;org.joda&quot; %% &quot;joda-beans&quot; % &quot;0.9.8&quot;</pre></div></div></div>
+<pre>libraryDependencies += &quot;org.joda&quot; % &quot;joda-beans&quot; % &quot;0.9.8&quot;</pre></div></div></div>
       </div>
     </div>
     <div class="clear">

--- a/joda-collect/dependency-info.html
+++ b/joda-collect/dependency-info.html
@@ -178,7 +178,7 @@
 <div class="section">
 <h3>SBT<a name="SBT"></a></h3><a name="SBT"></a>
 <div class="source">
-<pre>libraryDependencies += &quot;org.joda&quot; %% &quot;joda-collect&quot; % &quot;0.8-SNAPSHOT&quot;</pre></div></div></div>
+<pre>libraryDependencies += &quot;org.joda&quot; % &quot;joda-collect&quot; % &quot;0.8-SNAPSHOT&quot;</pre></div></div></div>
       </div>
     </div>
     <div class="clear">

--- a/joda-convert/dependency-info.html
+++ b/joda-convert/dependency-info.html
@@ -187,7 +187,7 @@
 <div class="section">
 <h3>SBT<a name="SBT"></a></h3><a name="SBT"></a>
 <div class="source">
-<pre>libraryDependencies += &quot;org.joda&quot; %% &quot;joda-convert&quot; % &quot;1.6&quot;</pre></div></div></div>
+<pre>libraryDependencies += &quot;org.joda&quot; % &quot;joda-convert&quot; % &quot;1.6&quot;</pre></div></div></div>
       </div>
     </div>
     <div class="clear">

--- a/joda-money/dependency-info.html
+++ b/joda-money/dependency-info.html
@@ -190,7 +190,7 @@
 <div class="section">
 <h3>SBT<a name="SBT"></a></h3><a name="SBT"></a>
 <div class="source">
-<pre>libraryDependencies += &quot;org.joda&quot; %% &quot;joda-money&quot; % &quot;0.9.1&quot;</pre></div></div></div>
+<pre>libraryDependencies += &quot;org.joda&quot; % &quot;joda-money&quot; % &quot;0.9.1&quot;</pre></div></div></div>
       </div>
     </div>
     <div class="clear">

--- a/joda-primitives/dependency-info.html
+++ b/joda-primitives/dependency-info.html
@@ -184,7 +184,7 @@
 <div class="section">
 <h3>SBT<a name="SBT"></a></h3><a name="SBT"></a>
 <div class="source">
-<pre>libraryDependencies += &quot;org.joda&quot; %% &quot;joda-primitives&quot; % &quot;1.1-SNAPSHOT&quot;</pre></div></div></div>
+<pre>libraryDependencies += &quot;org.joda&quot; % &quot;joda-primitives&quot; % &quot;1.1-SNAPSHOT&quot;</pre></div></div></div>
       </div>
     </div>
     <div class="clear">

--- a/joda-time-hibernate/dependency-info.html
+++ b/joda-time-hibernate/dependency-info.html
@@ -191,7 +191,7 @@
 <div class="section">
 <h3>SBT<a name="SBT"></a></h3><a name="SBT"></a>
 <div class="source">
-<pre>libraryDependencies += &quot;joda-time&quot; %% &quot;joda-time-hibernate&quot; % &quot;1.4-SNAPSHOT&quot;</pre></div></div></div>
+<pre>libraryDependencies += &quot;joda-time&quot; % &quot;joda-time-hibernate&quot; % &quot;1.4-SNAPSHOT&quot;</pre></div></div></div>
       </div>
     </div>
     <div class="clear">

--- a/joda-time-i18n/dependency-info.html
+++ b/joda-time-i18n/dependency-info.html
@@ -188,7 +188,7 @@
 <div class="section">
 <h3>SBT<a name="SBT"></a></h3><a name="SBT"></a>
 <div class="source">
-<pre>libraryDependencies += &quot;joda-time&quot; %% &quot;joda-time-i18n&quot; % &quot;0.2-SNAPSHOT&quot;</pre></div></div></div>
+<pre>libraryDependencies += &quot;joda-time&quot; % &quot;joda-time-i18n&quot; % &quot;0.2-SNAPSHOT&quot;</pre></div></div></div>
       </div>
     </div>
     <div class="clear">

--- a/joda-time-jsptags/dependency-info.html
+++ b/joda-time-jsptags/dependency-info.html
@@ -191,7 +191,7 @@
 <div class="section">
 <h3>SBT<a name="SBT"></a></h3><a name="SBT"></a>
 <div class="source">
-<pre>libraryDependencies += &quot;joda-time&quot; %% &quot;joda-time-jsptags&quot; % &quot;1.2-SNAPSHOT&quot;</pre></div></div></div>
+<pre>libraryDependencies += &quot;joda-time&quot; % &quot;joda-time-jsptags&quot; % &quot;1.2-SNAPSHOT&quot;</pre></div></div></div>
       </div>
     </div>
     <div class="clear">

--- a/joda-time/dependency-info.html
+++ b/joda-time/dependency-info.html
@@ -257,7 +257,7 @@
 <div class="section">
 <h3>SBT<a name="SBT"></a></h3><a name="SBT"></a>
 <div class="source">
-<pre>libraryDependencies += &quot;joda-time&quot; %% &quot;joda-time&quot; % &quot;2.4-SNAPSHOT&quot;</pre></div></div></div>
+<pre>libraryDependencies += &quot;joda-time&quot; % &quot;joda-time&quot; % &quot;2.4-SNAPSHOT&quot;</pre></div></div></div>
       </div>
     </div>
     <div class="clear">


### PR DESCRIPTION
With double '%' SBT tries to find the dependencies compiled with the
locally used Scala version. Since Joda doesn't use SBT/Scala this
results in an error like:

[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: joda-time#joda-time_2.10;2.3: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::

See:
http://www.scala-sbt.org/release/docs/Library-Management.html#Dependencies
